### PR TITLE
appointment booking flow between doctor and multiple patients

### DIFF
--- a/mhwp/booking.py
+++ b/mhwp/booking.py
@@ -328,7 +328,8 @@ class MHWPAppointmentManager():
                # Check for conflicts
                existing_appointments = appointments_relation.getRowsWhereEqual("patient_id", patient_id)
                for row in existing_appointments:
-                   if row[0] != appointment_id and row[5] == "Confirmed":  # Skip same appointment and non-confirmed
+                   if row[0] != appointment_id and row[5] in ["Pending",
+                                                              "Confirmed"]:  # Check both pending and confirmed
                        existing_date = row[3]
                        if isinstance(existing_date, datetime):
                            if (existing_date.date() == apt_date.date() and
@@ -339,7 +340,7 @@ class MHWPAppointmentManager():
                # Check room availability
                room_appointments = appointments_relation.getRowsWhereEqual("mhwp_id", self.mhwp_id)
                for row in room_appointments:
-                   if row[0] != appointment_id and row[5] == "Confirmed":
+                   if row[0] != appointment_id and row[5] in ["Pending", "Confirmed"]:
                        existing_date = row[3]
                        if isinstance(existing_date, datetime):
                            if (existing_date.date() == apt_date.date() and


### PR DESCRIPTION
Calendar management between doctor and multiple patients:
If a patient requests a slot, that slot becomes invisible to all other patients
If the doctor declines the request, the slot is freed and available on the calendar for patients to book
If a patient cancels a slot, it is freed again on the calendar for patients to book